### PR TITLE
docs: Cursor Cloud agent development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,64 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### What this repo is
+
+sensegrep is an **npm workspaces monorepo** (TypeScript, Node ≥18). There are **no Docker services or long-running HTTP servers**. Development centers on building packages and running Node CLIs:
+
+| Package | Role | After `npm run build` |
+|---------|------|------------------------|
+| `packages/core` | Search engine (`@sensegrep/core`) | `packages/core/dist/` |
+| `packages/cli` | CLI (`sensegrep`) | `node packages/cli/dist/main.js` |
+| `packages/mcp` | stdio MCP server | `node packages/mcp/dist/server.js` |
+| `packages/vscode` | VS Code/Cursor extension | `npm run dev --workspace sensegrep` (esbuild watch) |
+
+The `demo/` folder is a **separate** Remotion project (not in workspaces); only needed for marketing video scripts.
+
+### Standard commands (see also `CONTRIBUTING.md`)
+
+- Install: `npm ci` (CI uses lockfile; `npm install` also works)
+- Build: `npm run build` (`node build.js` — core → cli → mcp)
+- Typecheck: `npm run check` (runs `precheck` → build, then workspace `tsc`)
+- Tests: `npm test` (Vitest; **no API keys required**)
+- Version consistency: `npm run version:check`
+
+Root `npm run dev` is a **placeholder**; use package-specific commands above.
+
+### Lint / format
+
+There is **no ESLint/Prettier** at the repo root. “Lint” for this repo means **`npm run check`** (TypeScript `--noEmit` per workspace).
+
+### Semantic index and search (requires API keys)
+
+Indexing and semantic search use **remote embeddings only** (default provider: Gemini). CI does **not** set embedding keys.
+
+Before `sensegrep index` or semantic `search` / `survey` / `cluster`:
+
+- Set **`GEMINI_API_KEY`** or **`GOOGLE_API_KEY`**, or
+- Use **`--provider openai`** with **`SENSEGREP_OPENAI_API_KEY`** / **`FIREWORKS_API_KEY`**, or
+- Use **`--provider bedrock`** with AWS credentials.
+
+Example smoke flow (from repo root, after build):
+
+```bash
+export GEMINI_API_KEY=...
+node packages/cli/dist/main.js index --root . --no-watch
+node packages/cli/dist/main.js search "embedding configuration" --limit 3 --json
+```
+
+Without keys, `index` fails fast with a clear configuration error; `languages`, `status`, and MCP **initialize / tools/list** still work.
+
+### MCP server
+
+The MCP server speaks **stdio JSON-RPC**. It starts file watching by default; use a short `timeout` in scripted tests. Tools include `sensegrep_search`, `sensegrep_index`, `sensegrep_survey`, `sensegrep_cluster`, and `sensegrep_detect_duplicates`.
+
+### Optional: ripgrep
+
+`rg` on `PATH` is optional; core can download a ripgrep binary when missing.
+
+### Gotchas
+
+- **`npm run check` always rebuilds** via `precheck` → `npm run build`. If you change core, rebuild before exercising cli/mcp dist copies.
+- **VS Code extension** (`packages/vscode`) is not fully covered by root `npm test`; extension dev uses `npm run dev --workspace sensegrep`.
+- **No `.nvmrc`** — use Node 18+ (CI tests 18, 20, 22).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,44 +33,38 @@ There is **no ESLint/Prettier** at the repo root. “Lint” for this repo means
 
 Indexing and semantic search use **remote embeddings only**. CI does **not** configure providers.
 
-#### Recommended: Cohere via Amazon Bedrock
+#### Recommended: Cohere via Amazon Bedrock (Bedrock API key)
 
-Default Bedrock model in code: **`cohere.embed-v4:0`** (1536-dim). Cross-region / global inference ID: **`global.cohere.embed-v4:0`** (set via `SENSEGREP_EMBED_MODEL`).
+Default model: **`cohere.embed-v4:0`** (1536-dim). Global inference ID: **`global.cohere.embed-v4:0`** via `embedModel` in config.
 
-**Environment (CLI, MCP, extension):**
+Authentication is either:
 
-```bash
-export SENSEGREP_PROVIDER=bedrock
-export AWS_REGION=us-east-1          # or SENSEGREP_BEDROCK_REGION
-# Optional overrides:
-# export SENSEGREP_EMBED_MODEL=cohere.embed-v4:0
-# export SENSEGREP_EMBED_DIM=1536      # must be 256, 512, 1024, or 1536 for Cohere v4
-```
+1. **Bedrock API key** (prefix `ABSK…`) in `apiKey` — bearer token, **not** `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, or  
+2. **IAM** via the AWS SDK default chain (no `apiKey` in config).
 
-**AWS credentials:** standard AWS SDK chain (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, or instance/profile). No Gemini key is used when `SENSEGREP_PROVIDER=bedrock`.
-
-**Persistent config** (`~/.config/sensegrep/config.json`):
+**Canonical config file** — `~/.config/sensegrep/config.json`:
 
 ```json
 {
   "provider": "bedrock",
   "embedModel": "cohere.embed-v4:0",
   "embedDim": 1536,
-  "region": "us-east-1"
+  "region": "us-east-1",
+  "apiKey": "<Bedrock API key from console>"
 }
 ```
 
-**CLI flags** (override env for one run): `--provider bedrock` plus optional `--embed-model` / `--embed-dim`.
+`embedDim` must be **256, 512, 1024, or 1536** for Cohere Embed v4.
 
-**VS Code / Cursor:** `sensegrep.embeddings.provider` = `bedrock`, region via `sensegrep.embeddings.bedrockRegion` (see `packages/vscode/README.md`).
+**Cursor Cloud secret (preferred):** one secret named **`SENSEGREP_EMBEDDINGS_CONFIG`** whose value is the **entire JSON above** (minified one line is fine). The VM **update script** writes it to `~/.config/sensegrep/config.json` on startup. Do **not** use separate `GEMINI_API_KEY` or `AWS_ACCESS_KEY_ID` secrets for this setup.
 
-**IAM:** caller needs `bedrock:InvokeModel` on the chosen Cohere embedding model in that region (model access enabled in the Bedrock console).
+**Optional env overrides** (merge with / override file): `SENSEGREP_PROVIDER`, `SENSEGREP_EMBED_MODEL`, `SENSEGREP_EMBED_DIM`, `SENSEGREP_BEDROCK_REGION`.
 
-Example smoke flow (from repo root, after build):
+**VS Code / Cursor extension:** `sensegrep.embeddings.provider` = `bedrock`; for API-key auth, mirror the same fields in global `config.json` (extension does not store Bedrock keys in SecretStorage today).
+
+Example smoke flow (after build, with `config.json` in place):
 
 ```bash
-export SENSEGREP_PROVIDER=bedrock
-export AWS_REGION=us-east-1
 node packages/cli/dist/main.js index --root packages/core --no-watch
 node packages/cli/dist/main.js search "embedding configuration" --limit 3 --json
 ```
@@ -80,7 +74,7 @@ node packages/cli/dist/main.js search "embedding configuration" --limit 3 --json
 - **Gemini:** `GEMINI_API_KEY` / `GOOGLE_API_KEY` (default provider if unset and no OpenAI key)
 - **OpenAI-compatible:** `SENSEGREP_OPENAI_API_KEY` / `FIREWORKS_API_KEY` with `--provider openai`
 
-Without credentials, Bedrock fails with `CredentialsProviderError`; Gemini/OpenAI fail with explicit API-key errors. `languages`, `status`, and MCP **initialize / tools/list** still work without indexing.
+Without `apiKey` (and without IAM credentials), Bedrock fails with `CredentialsProviderError`. `languages`, `status`, and MCP **initialize / tools/list** still work without indexing.
 
 ### MCP server
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,25 +29,58 @@ Root `npm run dev` is a **placeholder**; use package-specific commands above.
 
 There is **no ESLint/Prettier** at the repo root. “Lint” for this repo means **`npm run check`** (TypeScript `--noEmit` per workspace).
 
-### Semantic index and search (requires API keys)
+### Semantic index and search (remote embeddings)
 
-Indexing and semantic search use **remote embeddings only** (default provider: Gemini). CI does **not** set embedding keys.
+Indexing and semantic search use **remote embeddings only**. CI does **not** configure providers.
 
-Before `sensegrep index` or semantic `search` / `survey` / `cluster`:
+#### Recommended: Cohere via Amazon Bedrock
 
-- Set **`GEMINI_API_KEY`** or **`GOOGLE_API_KEY`**, or
-- Use **`--provider openai`** with **`SENSEGREP_OPENAI_API_KEY`** / **`FIREWORKS_API_KEY`**, or
-- Use **`--provider bedrock`** with AWS credentials.
+Default Bedrock model in code: **`cohere.embed-v4:0`** (1536-dim). Cross-region / global inference ID: **`global.cohere.embed-v4:0`** (set via `SENSEGREP_EMBED_MODEL`).
+
+**Environment (CLI, MCP, extension):**
+
+```bash
+export SENSEGREP_PROVIDER=bedrock
+export AWS_REGION=us-east-1          # or SENSEGREP_BEDROCK_REGION
+# Optional overrides:
+# export SENSEGREP_EMBED_MODEL=cohere.embed-v4:0
+# export SENSEGREP_EMBED_DIM=1536      # must be 256, 512, 1024, or 1536 for Cohere v4
+```
+
+**AWS credentials:** standard AWS SDK chain (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, or instance/profile). No Gemini key is used when `SENSEGREP_PROVIDER=bedrock`.
+
+**Persistent config** (`~/.config/sensegrep/config.json`):
+
+```json
+{
+  "provider": "bedrock",
+  "embedModel": "cohere.embed-v4:0",
+  "embedDim": 1536,
+  "region": "us-east-1"
+}
+```
+
+**CLI flags** (override env for one run): `--provider bedrock` plus optional `--embed-model` / `--embed-dim`.
+
+**VS Code / Cursor:** `sensegrep.embeddings.provider` = `bedrock`, region via `sensegrep.embeddings.bedrockRegion` (see `packages/vscode/README.md`).
+
+**IAM:** caller needs `bedrock:InvokeModel` on the chosen Cohere embedding model in that region (model access enabled in the Bedrock console).
 
 Example smoke flow (from repo root, after build):
 
 ```bash
-export GEMINI_API_KEY=...
-node packages/cli/dist/main.js index --root . --no-watch
+export SENSEGREP_PROVIDER=bedrock
+export AWS_REGION=us-east-1
+node packages/cli/dist/main.js index --root packages/core --no-watch
 node packages/cli/dist/main.js search "embedding configuration" --limit 3 --json
 ```
 
-Without keys, `index` fails fast with a clear configuration error; `languages`, `status`, and MCP **initialize / tools/list** still work.
+#### Other providers (optional)
+
+- **Gemini:** `GEMINI_API_KEY` / `GOOGLE_API_KEY` (default provider if unset and no OpenAI key)
+- **OpenAI-compatible:** `SENSEGREP_OPENAI_API_KEY` / `FIREWORKS_API_KEY` with `--provider openai`
+
+Without credentials, Bedrock fails with `CredentialsProviderError`; Gemini/OpenAI fail with explicit API-key errors. `languages`, `status`, and MCP **initialize / tools/list** still work without indexing.
 
 ### MCP server
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud development guidance for the sensegrep monorepo.

**Update:** Documents **Cohere via Amazon Bedrock** as the recommended embedding setup (`SENSEGREP_PROVIDER=bedrock`, `cohere.embed-v4:0`, AWS SDK credentials/region) instead of Gemini-first instructions.

No application code changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed870a02-565b-4e4c-a9fa-a91375fb0a12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed870a02-565b-4e4c-a9fa-a91375fb0a12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

