### PR TITLE
Improve open-source positioning, docs, and npm metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/use_case.yml
+++ b/.github/ISSUE_TEMPLATE/use_case.yml
@@ -1,0 +1,57 @@
+name: Share your use case
+description: Tell us how you use sensegrep with AI coding agents, MCP, CLI, or CI.
+title: "[use case]: "
+labels:
+  - adoption
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Help others discover real workflows. Downloads are not the same as active users — your setup matters.
+  - type: dropdown
+    id: surface
+    attributes:
+      label: How do you use sensegrep?
+      options:
+        - Claude Code (plugin or MCP)
+        - Cursor (plugin or MCP)
+        - Windsurf (MCP)
+        - VS Code extension
+        - CLI only
+        - Custom agent / MCP client
+        - CI / shared index
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: workflow
+    attributes:
+      label: Workflow
+      description: What problem does sensegrep solve for you?
+      placeholder: e.g. parallel agents researching auth vs API layers on a monorepo...
+    validations:
+      required: true
+  - type: textarea
+    id: commands
+    attributes:
+      label: Commands or MCP tools
+      description: Example commands, env vars, or MCP tool names you rely on.
+      render: shell
+  - type: textarea
+    id: repo_context
+    attributes:
+      label: Codebase context
+      description: Language, approximate size, monorepo or not (no proprietary secrets).
+      placeholder: TypeScript monorepo, ~200k LOC, 3 packages...
+  - type: textarea
+    id: gaps
+    attributes:
+      label: What's missing?
+      description: Features, docs, or integrations that would make this easier.
+  - type: checkboxes
+    id: permission
+    attributes:
+      label: Attribution
+      options:
+        - label: I am okay being mentioned anonymously in docs (no name/company)
+        - label: I am okay being credited by name in docs (add your name/handle in the workflow field)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,42 @@
 # sensegrep
 
-**Semantic + structural code search for AI-native development.**
+**Semantic grep for AI coding agents.**
 
-[![npm version](https://img.shields.io/npm/v/@sensegrep/core)](https://www.npmjs.com/package/@sensegrep/core)
+[![npm version](https://img.shields.io/npm/v/@sensegrep/cli)](https://www.npmjs.com/package/@sensegrep/cli)
+[![npm downloads](https://img.shields.io/npm/dw/@sensegrep/cli)](https://www.npmjs.com/package/@sensegrep/cli)
+[![GitHub stars](https://img.shields.io/github/stars/Stahldavid/sensegrep)](https://github.com/Stahldavid/sensegrep/stargazers)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![CI](https://github.com/Stahldavid/sensegrep/actions/workflows/ci.yml/badge.svg)](https://github.com/Stahldavid/sensegrep/actions/workflows/ci.yml)
 
-sensegrep understands your code semantically. Instead of matching text patterns, it uses AI embeddings and tree-sitter AST parsing to find code by *meaning* - so you can search for "authentication logic" and actually find your auth functions, even if they never contain the word "authentication".
+AI coding agents should not read more code — they should read the **right** code.
+
+sensegrep combines **semantic search** (when you know the idea), **exact matching** (when you know the identifier), and **AST-aware structural filters** (when you need precision) — then returns smaller symbol-level slices instead of dumping whole files. Use it from the **CLI**, **MCP** (Claude Code, Cursor, Windsurf, custom agents), or the VS Code extension.
+
+```bash
+npm i -g @sensegrep/cli
+sensegrep index --root .
+sensegrep search "where user permissions are validated before protected routes" --type function --limit 15
+```
+
+```bash
+npx -y @sensegrep/mcp
+```
+
+### Why not only grep or only embeddings?
+
+| Approach | Strength | Weakness |
+|----------|----------|----------|
+| grep / ripgrep | Fast, exact | Needs the right string |
+| Semantic search | Finds concepts | Often noisy, broad |
+| sensegrep | Meaning + structure + exact mode | Requires index + embedding provider |
+
+## Early traction
+
+sensegrep is early, but npm shows real download activity across `@sensegrep/cli`, `@sensegrep/mcp`, and `@sensegrep/core` (on the order of **~700 combined weekly downloads** — not the same as active users). See [docs/traction.md](docs/traction.md) for how metrics are updated.
+
+**Use cases:** [parallel AI agents](docs/parallel-agents.md) · [all use cases](docs/use-cases.md) · [integration recipes](docs/recipes/README.md)
+
+If sensegrep helps your agent workflow, consider [starring the repo](https://github.com/Stahldavid/sensegrep) and sharing your setup in [Discussions](https://github.com/Stahldavid/sensegrep/discussions) or a [use case issue](https://github.com/Stahldavid/sensegrep/issues/new?template=use_case.yml).
 
 ![Sensegrep time-to-value demo](assets/time-to-value.gif)
 
@@ -290,6 +320,10 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, architecture overv
 
 ## Community
 
+- [Use cases](docs/use-cases.md)
+- [Parallel AI agents](docs/parallel-agents.md)
+- [Traction (public metrics)](docs/traction.md)
+- [GitHub Discussions](https://github.com/Stahldavid/sensegrep/discussions)
 - [Code of Conduct](CODE_OF_CONDUCT.md)
 - [Security Policy](SECURITY.md)
 - [Support](SUPPORT.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,6 +8,8 @@ This roadmap is intentionally short-horizon and focused on adoption + reliabilit
 - Publish reproducible case studies focused on practical search outcomes.
 - Improve repository onboarding with README media and faster time-to-value.
 - Standardize issue labels for contributor routing (`good first issue`, `help wanted`, etc.).
+- Document parallel-agent and MCP retrieval workflows ([use-cases.md](docs/use-cases.md), [parallel-agents.md](docs/parallel-agents.md)).
+- Track public traction honestly ([traction.md](docs/traction.md)).
 
 ## Next (Month 2): Benchmark Methodology
 

--- a/docs/community-discussions-seed.md
+++ b/docs/community-discussions-seed.md
@@ -1,0 +1,69 @@
+# GitHub Discussions — seed content
+
+Enable Discussions in the repository settings, then create these categories (if not already present): **General**, **Ideas**, **Q&A**.
+
+Pin these threads after creating them (copy/paste titles and bodies).
+
+---
+
+## 1. How are you using sensegrep?
+
+**Category:** General  
+**Pin:** yes
+
+Are you using sensegrep with Claude Code, Cursor, Windsurf, VS Code, MCP, CI, or a custom agent?
+
+Share your setup — especially:
+
+- agent workflows and orchestration  
+- MCP configuration  
+- large monorepos  
+- parallel agents over one index  
+- what's missing or confusing  
+
+Docs: [use cases](use-cases.md) · [parallel agents](parallel-agents.md) · [recipes](recipes/README.md)
+
+If you prefer an issue, use the [use case template](https://github.com/Stahldavid/sensegrep/issues/new?template=use_case.yml).
+
+---
+
+## 2. Roadmap: AI-agent code retrieval
+
+**Category:** Ideas  
+**Pin:** yes
+
+Short-horizon direction (see [ROADMAP.md](../ROADMAP.md)):
+
+- **Now:** recipes, case studies, onboarding, contributor labels  
+- **Next:** reproducible benchmarks vs ripgrep / ast-grep  
+- **Later:** more languages, editor ergonomics, migration guides  
+
+What would help **your** agent workflow most? Reply with one concrete request.
+
+---
+
+## 3. MCP integrations and client support
+
+**Category:** Q&A  
+**Pin:** yes
+
+Questions about `@sensegrep/mcp`, tool names, `SENSEGREP_ROOT`, watch mode, and client-specific setup.
+
+Starting points:
+
+- [mcp-setup.md](mcp-setup.md)  
+- [Claude Code recipe](recipes/claude-code.md)  
+- [Cursor recipe](recipes/cursor.md)  
+
+Post your `mcp.json` snippet (redact secrets) if something fails to connect.
+
+---
+
+## 4. Feature requests and missing workflows
+
+**Category:** Ideas  
+**Pin:** optional
+
+What should sensegrep do next for AI coding agents?
+
+Use this thread for brainstorming. For actionable tracking, open a [feature request](https://github.com/Stahldavid/sensegrep/issues/new?template=feature_request.yml) after consensus.

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -1,0 +1,214 @@
+# Distribution plan
+
+Ready-to-post drafts for sensegrep launch channels. **Do not post automatically** — review and publish manually.
+
+**Positioning:** sensegrep is semantic grep for AI coding agents (semantic + exact + AST-aware retrieval via CLI and MCP).
+
+**Honesty rules:**
+
+- Say **npm downloads**, not "users", unless you know who they are.
+- The project is **early**; ask for feedback.
+- Link to [use cases](use-cases.md) and [parallel agents](parallel-agents.md).
+
+---
+
+## Prioritized checklist
+
+| Priority | Action | Owner | Status |
+|----------|--------|-------|--------|
+| P0 | README hero + traction badges | repo | see PR |
+| P0 | `docs/parallel-agents.md` | repo | done |
+| P1 | Enable GitHub Discussions + seed threads | David | manual |
+| P1 | LinkedIn post 1 (downloads narrative) | David | manual |
+| P1 | LinkedIn post 2 (grep vs semantic vs sensegrep) | David | manual |
+| P2 | Follow-up email to Luca (parallel agents) | David | manual |
+| P2 | Submit to awesome MCP / AI coding lists | David | PRs |
+| P3 | Show HN | David | after P0–P1 |
+| P3 | Reddit r/ClaudeAI, r/cursor | David | after feedback on LinkedIn |
+
+---
+
+## Hacker News — Show HN
+
+**Title:** Show HN: sensegrep – semantic grep for AI coding agents
+
+**Body:**
+
+I built sensegrep because AI coding agents still struggle to retrieve the right code context.
+
+- **grep/ripgrep** — fast and exact, but only when you know the string.
+- **Semantic search** — good for concepts, often noisy and hard to narrow.
+- **AST tools** — precise structure, not meaning.
+
+sensegrep combines semantic search, exact matching (`--pattern`), tree-sitter structural filters (30+), AST-aware chunks, tree-shaking, and an MCP server for Claude Code, Cursor, Windsurf, and custom agents.
+
+CLI: `npm i -g @sensegrep/cli`  
+MCP: `npx -y @sensegrep/mcp`
+
+Repo: https://github.com/Stahldavid/sensegrep
+
+Early project with npm download traction; I'm trying to learn real agent workflows. Feedback especially welcome on MCP, parallel agents, and large repos.
+
+**Risk:** High scrutiny. README and demo must be clear before posting.
+
+---
+
+## Reddit — r/ClaudeAI
+
+**Title:** Semantic grep for Claude Code / MCP — looking for feedback on sensegrep
+
+**Body:**
+
+I maintain sensegrep (CLI + MCP). It targets a gap I keep hitting with coding agents: keyword grep when you know the symbol, noisy semantic search when you only know the idea.
+
+sensegrep tries to combine both plus AST filters so agents get smaller symbol-level chunks instead of full-file dumps. There's a Claude Code plugin and MCP tools (`search`, `survey`, `cluster`, `index`, `detect_duplicates`).
+
+https://github.com/Stahldavid/sensegrep
+
+Early stage — npm shows download activity but I'm still mapping real workflows. If you use Claude Code with MCP, I'd appreciate feedback on what's missing.
+
+**Risk:** Medium. Be ready to answer setup questions in comments.
+
+---
+
+## Reddit — r/cursor
+
+**Title:** sensegrep MCP + Cursor plugin — semantic + structural code search for agents
+
+**Body:**
+
+Sharing an OSS tool I've been building: sensegrep. Positioning is "semantic grep for AI coding agents" — semantic search + structural filters + exact match, with MCP and a Cursor plugin (marketplace pending in some cases; MCP install link in README).
+
+Useful when agents need to find code by meaning ("where is billing authorization checked?") without dumping entire files.
+
+Repo: https://github.com/Stahldavid/sensegrep  
+Parallel agent notes: https://github.com/Stahldavid/sensegrep/blob/main/docs/parallel-agents.md
+
+Looking for feedback from Cursor users on MCP ergonomics and agent workflows.
+
+---
+
+## Reddit — r/LocalLLaMA
+
+**Title:** Code retrieval layer for local / custom coding agents (sensegrep CLI + MCP)
+
+**Body:**
+
+For people running custom agent stacks: sensegrep indexes a repo with tree-sitter + embeddings (Gemini, OpenAI-compatible, or Bedrock) and exposes search via CLI and MCP.
+
+Not a model — a retrieval layer. Combines semantic search with AST filters and smaller chunks for context.
+
+https://github.com/Stahldavid/sensegrep
+
+Early project; honest about npm downloads vs unknown active users. Interested in how you handle code search in local agent setups.
+
+---
+
+## LinkedIn — Post 1 (downloads narrative)
+
+I thought nobody was using my open-source project.
+
+Then I checked npm.
+
+The sensegrep packages (`@sensegrep/cli`, `@sensegrep/mcp`, `@sensegrep/core`) are seeing on the order of **~700 combined downloads per week** across those packages — still early, and downloads ≠ active users, but real signal that people are trying the tooling.
+
+sensegrep is **semantic grep for AI coding agents**: CLI + MCP + structural filters so agents find code by meaning *and* by structure, without always dumping full files into context.
+
+I'm trying to understand who's using it and how — Claude Code, Cursor, Windsurf, custom MCP agents, parallel research workflows.
+
+If that's you, I'd really appreciate feedback or a GitHub star:
+https://github.com/Stahldavid/sensegrep
+
+---
+
+## LinkedIn — Post 2 (comparative advantage)
+
+Most AI coding agents still search code in one of two weak ways:
+
+**Keyword search** — fast and precise, but only if the agent already knows the exact name or string.
+
+**Semantic search** — better when the agent knows the idea, but often noisy and hard to constrain.
+
+That's the gap sensegrep targets. It's not "another embedding search box."
+
+It combines:
+
+- semantic search when you know the concept  
+- exact matching when you know the identifier  
+- AST-aware structural filters for precision  
+- symbol-level chunks + tree-shaking instead of full-file dumps  
+- MCP so Claude Code, Cursor, Windsurf, and custom agents can use it as a tool  
+
+Example intent: *"Where do we validate user permissions before protected routes?"* — not just `auth` grep.
+
+Thesis: **AI agents should not read more code. They should read the right code.**
+
+https://github.com/Stahldavid/sensegrep
+
+---
+
+## LinkedIn — Post 4 (parallel agents)
+
+One workflow I care about: **parallel AI coding agents** on the same repository.
+
+Split research:
+
+- Agent 1 → authentication  
+- Agent 2 → data layer  
+- Agent 3 → API routes  
+- Agent 4 → frontend state  
+
+The bottleneck is usually shared context: re-indexing, overlapping grep hits, or dumping huge files into every prompt.
+
+sensegrep uses one index per repo, then `search` / `survey` / `cluster` with structural filters so each agent can pull smaller, more relevant slices.
+
+Wrote up the pattern here:
+https://github.com/Stahldavid/sensegrep/blob/main/docs/parallel-agents.md
+
+Curious how others handle retrieval across parallel agents.
+
+---
+
+## Direct outreach (DM / email template)
+
+Hi — I'm David, author of sensegrep (semantic grep for AI coding agents — CLI + MCP).
+
+I saw you're working on [ctx / agent orchestration / MCP]. I'm especially interested in how teams handle **code retrieval and shared context when multiple agents search the same repo in parallel**.
+
+If you've tried `@sensegrep/mcp`, I'd love 15 minutes of feedback — what's missing, what's redundant, and whether the MCP tools fit your orchestration model.
+
+No pitch — mostly learning from builders in this space.
+
+Thanks,  
+David
+
+---
+
+## Awesome lists — PR template
+
+**Title:** Add sensegrep — semantic grep for AI coding agents (CLI + MCP)
+
+**Body:**
+
+- **Repo:** https://github.com/Stahldavid/sensegrep  
+- **npm:** `@sensegrep/cli`, `@sensegrep/mcp`  
+- **MCP registry:** `io.github.Stahldavid/sensegrep`  
+- **Summary:** Semantic + structural code search with tree-sitter, embeddings, and MCP tools for AI coding assistants (Claude Code, Cursor, Windsurf).
+
+**Category:** [MCP servers / AI coding / code search — pick list-appropriate section]
+
+---
+
+## MCP directories
+
+- Official registry entry via `server.json` (see [week1-launch-checklist.md](week1-launch-checklist.md))
+- Verify listing after each `@sensegrep/mcp` release
+
+---
+
+## Manual approval points
+
+- [ ] All posts reviewed for accurate download numbers ([traction.md](traction.md))
+- [ ] No false "thousands of users" claims
+- [ ] Luca / third parties not named without permission
+- [ ] Show HN only after Discussions seeded and README updated

--- a/docs/parallel-agents.md
+++ b/docs/parallel-agents.md
@@ -1,0 +1,115 @@
+# Parallel AI coding agents
+
+Luca King ([@luca-ctx](https://github.com/luca-ctx)) and others building agent orchestration often ask: **can multiple agents search the same codebase in parallel without each one re-indexing or dumping full files?**
+
+sensegrep is designed for that pattern.
+
+## Problem
+
+Running several agents on one repo usually fails in one of two ways:
+
+1. **Keyword-only search** — each agent greps different strings and opens huge files.
+2. **Noisy semantic search** — each agent gets broad, overlapping chunks and blows the context window.
+
+The hard part is not starting multiple agents. It is giving each agent **the right slice of code** from a **shared understanding** of the repo.
+
+## How sensegrep helps
+
+```text
+                    ┌─────────────────────┐
+                    │  sensegrep index    │
+                    │  (once per repo)    │
+                    └──────────┬──────────┘
+                               │
+         ┌─────────────────────┼─────────────────────┐
+         ▼                     ▼                     ▼
+   ┌───────────┐         ┌───────────┐         ┌───────────┐
+   │  Agent 1  │         │  Agent 2  │         │  Agent 3  │
+   │   auth    │         │   API     │         │  frontend │
+   └─────┬─────┘         └─────┬─────┘         └─────┬─────┘
+         │ survey/search       │ cluster/search      │ search
+         ▼                     ▼                     ▼
+   smaller AST-aware     subthemes +        filtered symbols
+   symbol chunks         reading map        (not full files)
+```
+
+1. **Shared index** — `sensegrep index --root .` (or MCP `sensegrep.index`) builds one LanceDB index for the tree.
+2. **Partitioned research** — each agent uses `search`, `survey`, or `cluster` on a different theme.
+3. **Structural precision** — filters (`--type`, `--exported`, `--language`, `--include`, etc.) reduce overlap between agents.
+4. **Tree-shaking** — results favor relevant symbols over entire file dumps.
+
+## CLI example
+
+Index once:
+
+```bash
+sensegrep index --root .
+```
+
+Agent-style splits (run in separate terminals or jobs):
+
+```bash
+# Agent 1 — auth
+sensegrep survey "authentication session token middleware" --language typescript --limit 4
+
+# Agent 2 — persistence
+sensegrep survey "database model repository migration" --limit 4
+
+# Agent 3 — HTTP surface
+sensegrep search "request validation route handler" --type function --limit 15
+
+# Agent 4 — broad theme → subthemes
+sensegrep cluster "checkout payment cart order" --limit 4
+```
+
+Merge findings at the orchestration layer (your agent framework), not inside sensegrep.
+
+## MCP example
+
+Multiple MCP clients (or parallel tool calls from one orchestrator) can use the same server with `SENSEGREP_ROOT` set to the repository root:
+
+```json
+{
+  "servers": {
+    "sensegrep": {
+      "command": "npx",
+      "args": ["-y", "@sensegrep/mcp"],
+      "env": {
+        "SENSEGREP_ROOT": "/path/to/your/repo"
+      }
+    }
+  }
+}
+```
+
+Optional: `SENSEGREP_WATCH=true` keeps the index fresh when files change (rate-limited reindex). See [mcp-setup.md](mcp-setup.md).
+
+Typical tool split per agent:
+
+| Tool | When to use |
+|------|-------------|
+| `sensegrep.survey` | Map a domain (auth, billing, infra) |
+| `sensegrep.cluster` | Split a vague topic into subthemes |
+| `sensegrep.search` | Precise retrieval with filters |
+| `sensegrep.detect_duplicates` | Cross-cutting refactor candidates |
+
+## Deduplication across agents
+
+sensegrep does not merge agent outputs automatically. Recommended practices:
+
+- Assign **non-overlapping themes** per agent (`survey`/`cluster` first).
+- Use **`--include` / `--exclude` globs** per agent to scope paths.
+- Cap **`--limit`** on search to keep slices small.
+- Let the orchestrator dedupe file paths and symbol names in final context.
+
+## When this is not enough
+
+You still need an orchestration layer for task planning, patches, and PRs. sensegrep is the **retrieval layer** — semantic + structural + exact — not a multi-agent framework.
+
+## Next steps
+
+- [Use cases](use-cases.md)
+- [Claude Code recipe](recipes/claude-code.md)
+- [MCP setup](mcp-setup.md)
+
+If you run parallel agents with sensegrep, share your setup in [GitHub Discussions](https://github.com/Stahldavid/sensegrep/discussions) or a [use case issue](https://github.com/Stahldavid/sensegrep/issues/new?template=use_case.yml).

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -2,6 +2,11 @@
 
 Production-ready setup and workflow recipes for common sensegrep usage paths.
 
+## Related guides
+
+- [Use cases](../use-cases.md)
+- [Parallel AI agents](../parallel-agents.md)
+
 ## Available Recipes
 
 - [Claude Code](claude-code.md)

--- a/docs/traction.md
+++ b/docs/traction.md
@@ -1,0 +1,37 @@
+# Traction
+
+sensegrep is early-stage. Public signals below are updated manually from npm and GitHub APIs. **Downloads are not the same as active users** — many installs come from `npx`, CI, or one-off trials.
+
+## How to refresh
+
+```bash
+# Weekly downloads (per package)
+curl -s "https://api.npmjs.org/downloads/point/last-week/@sensegrep/cli" | jq .downloads
+curl -s "https://api.npmjs.org/downloads/point/last-week/@sensegrep/mcp" | jq .downloads
+curl -s "https://api.npmjs.org/downloads/point/last-week/@sensegrep/core" | jq .downloads
+
+# GitHub
+gh repo view Stahldavid/sensegrep --json stargazerCount,forkCount,openIssues
+```
+
+## Snapshot (2026-06-04)
+
+| Signal | Value | Notes |
+|--------|------:|-------|
+| `@sensegrep/cli` weekly downloads | ~200 | npm registry |
+| `@sensegrep/mcp` weekly downloads | ~250 | npm registry |
+| `@sensegrep/core` weekly downloads | ~255 | npm registry |
+| Combined weekly (cli + mcp + core) | **~700** | Sum of packages above |
+| Typical monthly downloads per package | ~1.6k–1.9k | Varies by release cadence |
+| GitHub stars | check badge / `gh repo view` | Social proof for visitors |
+| Published npm version | 1.5.2 | `@sensegrep/cli`, `core`, `mcp` |
+| MCP registry | `io.github.Stahldavid/sensegrep` | See `server.json` |
+| Integrations | Claude Code plugin, Cursor plugin, VS Code, MCP | See [README](../README.md) |
+
+## What we are optimizing for
+
+1. **Real workflows** — agents, MCP, large repos, parallel research (see [use cases](use-cases.md)).
+2. **Honest feedback** — GitHub Discussions and [use case issues](https://github.com/Stahldavid/sensegrep/issues/new?template=use_case.yml).
+3. **Repeatable outcomes** — [case studies](case-studies.md) and integration [recipes](recipes/README.md).
+
+If sensegrep helps your agent workflow, a GitHub star and a short note about your setup help others discover the project.

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,0 +1,72 @@
+# Use cases
+
+sensegrep is **semantic grep for AI coding agents**: semantic search, exact matching, AST-aware structural filters, and smaller code slices for agent context — via [CLI](cli-reference.md) and [MCP](mcp-setup.md).
+
+## Parallel AI coding agents
+
+Split research across agents on the **same repository** and reuse one on-disk index:
+
+| Agent | Focus | Example command |
+|-------|--------|-----------------|
+| 1 | Authentication | `sensegrep survey "authentication login token" --language typescript --limit 4` |
+| 2 | Data layer | `sensegrep survey "database models migrations" --limit 4` |
+| 3 | API surface | `sensegrep search "route handlers middleware" --type function --limit 15` |
+| 4 | Frontend state | `sensegrep cluster "checkout cart state" --limit 4` |
+
+All agents can point at the same project root. Index once (`sensegrep index --root .`), then search in parallel processes or separate MCP sessions.
+
+See [Parallel agents](parallel-agents.md) for architecture notes and MCP setup.
+
+## Onboarding unfamiliar repositories
+
+Ask by **concept** instead of guessing identifiers:
+
+```bash
+sensegrep index --root .
+sensegrep search "where user permissions are validated before protected routes" --type function --limit 20
+```
+
+Combine with `survey` and `cluster` to build a reading map before editing code.
+
+## Refactoring large codebases
+
+Use structural filters to narrow semantic results:
+
+```bash
+sensegrep search "error handling retry" --type function --async --min-complexity 5
+sensegrep search "business logic" --min-complexity 10 --has-docs false
+```
+
+Tree-shaking collapses irrelevant symbols so agents see **functions and classes**, not whole files.
+
+## Duplicate logic detection
+
+Find cross-file logical duplicates for cleanup tickets:
+
+```bash
+sensegrep detect-duplicates --cross-file-only --threshold 0.85 --show-code
+```
+
+## MCP as a code retrieval layer
+
+Expose search to Claude Code, Cursor, Windsurf, or custom agents:
+
+```bash
+npx -y @sensegrep/mcp
+```
+
+Tools include `sensegrep.search`, `sensegrep.survey`, `sensegrep.cluster`, `sensegrep.index`, and `sensegrep.detect_duplicates`. Recipes:
+
+- [Claude Code](recipes/claude-code.md)
+- [Cursor](recipes/cursor.md)
+- [Windsurf](recipes/windsurf.md)
+
+## CI and shared indexes
+
+Index in CI or on a shared runner so agents and humans share the same semantic index. See [GitHub Actions recipe](recipes/ci-github-actions.md).
+
+## Related docs
+
+- [Case studies](case-studies.md) — reproducible examples on public repos
+- [Architecture](architecture.md)
+- [Traction](traction.md) — public usage signals (honest metrics)

--- a/examples/parallel-agents/README.md
+++ b/examples/parallel-agents/README.md
@@ -1,0 +1,34 @@
+# Parallel agents example
+
+One shared index, multiple research themes. See [docs/parallel-agents.md](../../docs/parallel-agents.md) for architecture and MCP notes.
+
+## Prerequisites
+
+```bash
+npm i -g @sensegrep/cli
+export GEMINI_API_KEY="your_key"   # or another supported provider
+cd /path/to/your/repo
+sensegrep index --root .
+```
+
+## Split research (run in separate terminals)
+
+```bash
+# Theme 1 — authentication
+sensegrep survey "authentication session token middleware" --limit 4
+
+# Theme 2 — persistence
+sensegrep survey "database model repository migration" --limit 4
+
+# Theme 3 — HTTP / API
+sensegrep search "request validation route handler" --type function --limit 15
+
+# Theme 4 — decompose a broad product area
+sensegrep cluster "checkout payment cart order" --limit 4
+```
+
+Merge results in your orchestrator (task planner, lead agent, or human review). sensegrep does not deduplicate across agents automatically — scope each agent with `--include` / `--exclude` when paths overlap.
+
+## MCP
+
+Point multiple clients at the same repo with `SENSEGREP_ROOT`. See [docs/mcp-setup.md](../../docs/mcp-setup.md).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@sensegrep/cli",
   "version": "1.5.2",
+  "description": "CLI for sensegrep — semantic grep for AI coding agents (semantic + structural code search).",
   "type": "module",
   "bin": {
     "sensegrep": "dist/main.js"
@@ -33,5 +34,24 @@
   "homepage": "https://github.com/Stahldavid/sensegrep",
   "bugs": {
     "url": "https://github.com/Stahldavid/sensegrep/issues"
-  }
+  },
+  "keywords": [
+    "sensegrep",
+    "cli",
+    "grep",
+    "ripgrep",
+    "semantic-search",
+    "code-search",
+    "semantic-code-search",
+    "code-retrieval",
+    "ai-agents",
+    "ai-coding",
+    "claude-code",
+    "cursor",
+    "windsurf",
+    "mcp",
+    "tree-sitter",
+    "ast",
+    "developer-tools"
+  ]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@sensegrep/core",
   "version": "1.5.2",
+  "description": "Core library for sensegrep — semantic + structural code search for AI coding agents.",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -46,5 +47,17 @@
   "homepage": "https://github.com/Stahldavid/sensegrep",
   "bugs": {
     "url": "https://github.com/Stahldavid/sensegrep/issues"
-  }
+  },
+  "keywords": [
+    "sensegrep",
+    "semantic-search",
+    "code-search",
+    "code-retrieval",
+    "ai-agents",
+    "tree-sitter",
+    "ast",
+    "embeddings",
+    "lancedb",
+    "developer-tools"
+  ]
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@sensegrep/mcp",
+  "description": "MCP server for sensegrep — semantic grep for AI coding assistants (Claude Code, Cursor, Windsurf).",
   "mcpName": "io.github.Stahldavid/sensegrep",
   "version": "1.5.2",
   "type": "module",
@@ -42,7 +43,17 @@
     "mcp",
     "mcp-server",
     "semantic-search",
+    "semantic-code-search",
+    "code-search",
+    "code-retrieval",
     "ai-agents",
-    "code-search"
+    "ai-coding",
+    "claude-code",
+    "cursor",
+    "windsurf",
+    "grep",
+    "tree-sitter",
+    "ast",
+    "developer-tools"
   ]
 }

--- a/scripts/github/labels.json
+++ b/scripts/github/labels.json
@@ -58,5 +58,25 @@
     "name": "performance",
     "color": "ff9f1c",
     "description": "Latency, memory, and runtime efficiency"
+  },
+  {
+    "name": "ai-agents",
+    "color": "7057ff",
+    "description": "AI coding agent and orchestration workflows"
+  },
+  {
+    "name": "examples",
+    "color": "d4c5f9",
+    "description": "Sample projects and example workflows"
+  },
+  {
+    "name": "cli",
+    "color": "ededed",
+    "description": "Command-line interface"
+  },
+  {
+    "name": "use case",
+    "color": "f9d0c4",
+    "description": "Real-world usage reports from users"
   }
 ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Turns sensegrep’s public surface into a clearer “semantic grep for AI coding agents” story: README conversion, honest traction signals, parallel-agent documentation, distribution drafts, and npm/discovery metadata.

## Changes

### README
- New hero: positioning, install snippets, grep vs semantic table, early traction (~700 combined weekly downloads, with honest caveat)
- Badges: npm downloads, GitHub stars
- Links to use cases, parallel agents, Discussions, use-case issue template

### Docs
- `docs/use-cases.md` — six practical workflows
- `docs/parallel-agents.md` — shared index + MCP pattern (answers the Luca-style question)
- `docs/traction.md` — how to refresh metrics; snapshot 2026-06-04
- `docs/distribution.md` — HN, Reddit, LinkedIn drafts (manual post only)
- `docs/community-discussions-seed.md` — text to paste when enabling Discussions
- `examples/parallel-agents/README.md` — copy-paste CLI split

### Community / npm
- `.github/ISSUE_TEMPLATE/use_case.yml`
- Expanded `scripts/github/labels.json` (`ai-agents`, `examples`, `cli`, `use case`)
- `description` + `keywords` on `@sensegrep/cli`, `@sensegrep/core`; expanded `@sensegrep/mcp` keywords

## Verification

- `npm run check` passes

## Manual follow-ups (repo owner)

1. Enable **GitHub Discussions** and paste threads from `docs/community-discussions-seed.md`
2. Run `npm run repo:labels:apply` (needs `gh auth login`)
3. Publish npm **patch** if you want keywords live on registry (`1.5.3`)
4. LinkedIn / follow-up Luca / Show HN using `docs/distribution.md` after merge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd2d7a5e-3164-4ba6-a7fb-7bf673cb8bbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd2d7a5e-3164-4ba6-a7fb-7bf673cb8bbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

